### PR TITLE
PR for the Woodland Direct Challenge - do NOT merge

### DIFF
--- a/learning-center/learning-center.css
+++ b/learning-center/learning-center.css
@@ -96,7 +96,7 @@ body {
 }
 
 div {
-  font-family: 'Open Sans', 'Trebuchet MS', sans-serif;
+  /*font-family: 'Open Sans', 'Trebuchet MS', sans-serif;*/
   font-family: var(--font-body);
   -webkit-font-smoothing: antialiased;
 }

--- a/src/components/modals/QuotesModal.jsx
+++ b/src/components/modals/QuotesModal.jsx
@@ -75,7 +75,7 @@ const QuotesModal = props => {
         type={'input'}
         label={'Header'}
         name={'header'}
-        error={data['header'] ? data['header'].value : null}
+        error={data['header'] ? data['header'].error : null}
         updateFormData={updateFormData}
         value={data['header'] ? data['header'].value : ''}
         required
@@ -84,7 +84,7 @@ const QuotesModal = props => {
         type={'input'}
         label={'Body Text'}
         name={'bodyText'}
-        error={data['bodyText'] ? data['bodyText'].value : null}
+        error={data['bodyText'] ? data['bodyText'].error : null}
         updateFormData={updateFormData}
         value={data['bodyText'] ? data['bodyText'].value : ''}
         required


### PR DESCRIPTION
This was a little odd to do without a good understanding of what users the app is targeted at, what documentation they have available to them, and just how it all is supposed to function. I found some code changes that I feel should happen and made the edits there. The rest of it is more personal opinion and experience with similar functionality.

Actual code changes
- In the css there are a lot of duplicated values, where both the hard coded version and the variable version are used. Is there a reason for this duplication? If there isn't, the css should probably rely on the variables so that core changes made to those are easily reflected across the site. Commented one of the lines out to show what I am talking about.
- In the QuotesModal.jsx file, found an issue where the error validation wasn't being applied to the form fields on the modal. Only the error message saying to please fill out all required fields was showing and the forms fields were not getting the error styling unless you clicked into them.

Some additional comments / feedback on the project all together
- Check and see if all fields are actually required (Banner template is a good example where the sub title might not be needed, but not sure cause I've no idea what the styleguide is like, just based off of experience in the past).
- Different button options available based on site style guide (looks like the solid orange is the most common but there are white background/orange border ones with a solid orange hover in some spots on the current woodland direct site).
- Ability to change what side the button text template has the CTA and the button on (like button on the left or right side).
- Have the entire page builder view pushed over to the right more so that you can see/click on the full page without it being covered by the menu  pop out even when it is collapsed. Another option would be to change the pop over menu when it is collapsed to just the top bit that has the arrows and keep it only the height on the top nav area so that the main page section itself doesn't always have a hidden bit.
- On the gallery, hide the dropdown/buttons if there is only one gallery present so that there isn't a button going nowhere just sitting there
- Add some kind of visual element to show what fields are required before the user clicks the save button. Noting what fields are optional is good, but it seems to be more common place and user friendly to include a clear visual of what fields are actually required as users scan forms